### PR TITLE
Make Send bound optional for AsyncTestContext

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,11 @@ authors = ["Mark Hildreth <mark.k.hildreth@gmail.com>"]
 license = "MIT"
 categories = ["development-tools::testing"]
 
+[features]
+default = ["async_send"]
+# Require async futures to be Send
+async_send = ["test-context-macros/async_send"]
+
 [dependencies]
 test-context-macros = { version = "0.1.4", path = "macros" }
 async-trait = "0.1.42"

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -12,6 +12,10 @@ license = "MIT"
 [lib]
 proc-macro = true
 
+[features]
+# Require async futures to be Send
+async_send = []
+
 [dependencies]
 quote = "1.0.3"
 syn = { version = "^1", features = ["full"] }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -51,7 +51,22 @@ struct AsyncContext {
     n: u32,
 }
 
+#[cfg(feature = "async_send")]
 #[async_trait::async_trait]
+impl AsyncTestContext for AsyncContext {
+    async fn setup() -> Self {
+        Self { n: 1 }
+    }
+
+    async fn teardown(self) {
+        if self.n != 1 {
+            panic!("Number changed");
+        }
+    }
+}
+
+#[cfg(not(feature = "async_send"))]
+#[async_trait::async_trait(?Send)]
 impl AsyncTestContext for AsyncContext {
     async fn setup() -> Self {
         Self { n: 1 }


### PR DESCRIPTION
`AsyncTestContext` was originally implemented by using `#[async_trait::async_trait]`. Unfortunately this forces futures to be `Send` which sometimes unfeasible.
I've added a separate feature to the create `async_send` which is on by default. This way by default crate behaves identically to previous version. But if you disable this feature then `AsyncTestContext` will be created with `#[async_trait::async_trait(?Send)]` which allows futures to be not `Send`.
I wasn't able to think about any other mechanism other than feature flag. It would be great if you come up with something and it won't be a breaking change.