### PR TITLE
fix: clippy unit test on doctests warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! A library for providing custom setup/teardown for Rust tests without needing a test harness.
 //!
-//! ```
+//! ```no_run
 //! use test_context::{test_context, TestContext};
 //!
 //! struct MyContext {


### PR DESCRIPTION
Clippy is reporting a warning because you can't write unit tests inside doc tests.

To fix it, the suggested solution is to mark the code example with `no_run`. 

This will tell rust to make sure the example compiles but to not run it.