### PR TITLE
refactor: remove support for async-trait crate

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ struct MyAsyncContext {
     value: String
 }
 
-#[async_trait::async_trait]
 impl AsyncTestContext for MyAsyncContext {
     async fn setup() -> MyAsyncContext {
         MyAsyncContext { value: "Hello, World!".to_string() }

--- a/test-context-macros/src/lib.rs
+++ b/test-context-macros/src/lib.rs
@@ -9,7 +9,6 @@ use quote::{format_ident, quote};
 /// ```ignore
 /// #[test_context(MyContext)]
 /// #[test]
-/// #[ignore]
 /// fn my_test() {
 /// }
 /// ```
@@ -18,7 +17,6 @@ use quote::{format_ident, quote};
 ///
 /// ```ignore
 /// #[test]
-/// #[ignore]
 /// #[test_context(MyContext)]
 /// fn my_test() {
 /// }

--- a/test-context/Cargo.toml
+++ b/test-context/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "test-context"
+rust-version = "1.75.0"
 description = "A library for providing custom setup/teardown for Rust tests without needing a test harness"
 readme = "../README.md"
 keywords = ["test", "setup", "teardown"]
@@ -13,7 +14,6 @@ license.workspace = true
 
 [dependencies]
 test-context-macros = { version = "0.1.6", path = "../test-context-macros/" }
-async-trait = "0.1.42"
 futures = "0.3"
 
 [dev-dependencies]

--- a/test-context/tests/test.rs
+++ b/test-context/tests/test.rs
@@ -51,7 +51,6 @@ struct AsyncContext {
     n: u32,
 }
 
-#[async_trait::async_trait]
 impl AsyncTestContext for AsyncContext {
     async fn setup() -> Self {
         Self { n: 1 }


### PR DESCRIPTION
Async traits in Rust were stabilized with the release of the [1.75 version](https://blog.rust-lang.org/2023/12/28/Rust-1.75.0.html)

I am removing the support for async-trait since its no longer required and setting the minimum supported rust version to 1.75