### PR TITLE
chore: upgrade to 0.2.0 version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,8 @@ members = ["test-context", "test-context-macros"]
 
 [workspace.package]
 edition = "2021"
-version = "0.1.6"
+version = "0.2.0"
+rust-version = "1.75.0"
 homepage = "https://github.com/JasterV/test-context"
 repository = "https://github.com/JasterV/test-context"
 authors = [

--- a/test-context-macros/Cargo.toml
+++ b/test-context-macros/Cargo.toml
@@ -2,6 +2,7 @@
 name = "test-context-macros"
 description = "Macro crate for test-context"
 version.workspace = true
+rust-version.workspace = true
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/test-context/Cargo.toml
+++ b/test-context/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "test-context"
-rust-version = "1.75.0"
 description = "A library for providing custom setup/teardown for Rust tests without needing a test harness"
 readme = "../README.md"
 keywords = ["test", "setup", "teardown"]
 categories = ["development-tools::testing"]
+rust-version.workspace = true
 version.workspace = true
 edition.workspace = true
 homepage.workspace = true
@@ -13,7 +13,7 @@ authors.workspace = true
 license.workspace = true
 
 [dependencies]
-test-context-macros = { version = "0.1.6", path = "../test-context-macros/" }
+test-context-macros = { version = "0.2.0", path = "../test-context-macros/" }
 futures = "0.3"
 
 [dev-dependencies]


### PR DESCRIPTION
Upgrading the minor version.
The Rust Minimum supported version has been upgraded to 1.75.0 since the support for the `async-trait` was removed in #37 